### PR TITLE
chore: Explicitly add missing runtime dependency

### DIFF
--- a/SalesforceToServiceNow.java
+++ b/SalesforceToServiceNow.java
@@ -1,6 +1,7 @@
 // camel-k: language=java
 // camel-k: config=secret:secret-saas
 // camel-k: dependency=camel:servicenow
+// camel-k: dependency=mvn:javax.ws.rs:javax.ws.rs-api:2.1
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.salesforce.SalesforceEndpointConfig;


### PR DESCRIPTION
camel-servicenow 3.14.2+ requires javax.ws.rs-api dependency

Required to run the quickstart with camel-quarkus 2.7.1+